### PR TITLE
FAQ-Section: update 5

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,7 @@
             <div class="hdivider"></div>
 
             <div class="faq-intro">
-                <p>Here you can find the most frequently asked questions related to the hackathon, you may find answers to yours!
+                <p class="faq-text">Here you can find the most frequently asked questions related to the hackathon, you may find answers to yours!
                 </p>
             </div>
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -537,11 +537,12 @@ Team
 /*
 /////////////////////////// FAQ SECTION
 */
-
+.faq-text {
+    font-size: 18px;
+}
 .faq-intro {
     padding: 2% 0;
     line-height: 1.8;
-    font-size: 18px;
 }
 
 .faq-main {
@@ -554,7 +555,6 @@ Team
     position: relative;
     padding: 8px;
     max-width: 700px;
-    width: 600px;
 }
 
 input {
@@ -573,6 +573,7 @@ input {
     border-radius: 4px;
     margin-bottom: 0px;
     box-shadow: 2px 2px 3px 3px rgba(0, 0, 0, 0.1);
+    font-size: 20px;
 }
 
 .question h3:hover {
@@ -645,7 +646,6 @@ input:checked~.question .fa.fa-arrow-right {
 .faq-hacker-guide {
     padding: 35px 0;
     font-size: 18px;
-    font-weight: 600;
     line-height: 2;
 }
 


### PR DESCRIPTION
Fixes and closes #14  
- Fixing `faq-tab` overboard size before responsivity threshold
- Fix question font size
- warping faq intro text in `faq-text` class

### Preview
|||
|--|--|
|![image](https://user-images.githubusercontent.com/43890965/202589195-5ea896de-c1f8-4966-bb0d-0fad1837b9bb.png)|![image](https://user-images.githubusercontent.com/43890965/202589305-51ff4eab-11af-4b94-b4c8-6ed454aeb07f.png)|
